### PR TITLE
Don't work with pjax loaded page

### DIFF
--- a/dist/loconative-scroll.js
+++ b/dist/loconative-scroll.js
@@ -1029,6 +1029,7 @@
     if (!window.getComputedStyle) return;
     var style = getComputedStyle(el);
     var transform = style.transform || style.webkitTransform || style.mozTransform;
+    // mat is undefined for pages loaded using pjax
     var mat = transform.match(/^matrix3d\((.+)\)$/);
 
     if (mat) {


### PR DESCRIPTION
Hello

Firstly, excuse me to create a pull request without provide a solution to that bug yet, but I don't see the issue tab for that repository, so I didn't know how to communicate about that bug.

Loconative stop working for pages that are loaded using PJAX technic. It's not only the loconative features, it's the whole scroll that stop to work, so I think it's the problem come from the lenis integration of loconative.

I tested with the core lenis library, without loconative, it works well between pjax pages, so the issue is not related to lenis itself.

I didn't find why actually

For people having the same problem, I found a quick and dirty workaround actually : 

- Load lenis manally
- Load loconative and define smooth to false
That way, I can get my smooth scroll to work between my pages. I can't use data-scroll-x features, but the .on('scroll') still work. This is the best result I can have actually